### PR TITLE
OmniAuth authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'puma'
 gem 'faye-websocket'
 gem 'haml'
 gem 'omniauth'
+gem 'omniauth-google-oauth2'
 gem 'jquery-rails'
 gem 'date_validator'            # datetime validations for ActiveRecord
 gem 'foreman'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
 end
 
 group :production do
+  gem 'rack-ssl-enforcer'
   gem 'newrelic_rpm'
   gem 'rails_12factor'
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
     factory_girl_rails (4.4.1)
       factory_girl (~> 4.4.0)
       railties (>= 3.0.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
     fattr (2.2.2)
     faye-websocket (0.7.3)
       eventmachine (>= 0.12.0)
@@ -149,6 +151,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     json_pure (1.8.1)
+    jwt (1.0.0)
     launchy (2.4.2)
       addressable (~> 2.3)
     mail (2.5.4)
@@ -179,12 +182,28 @@ GEM
     mini_portile (0.6.0)
     multi_json (1.10.1)
     multi_test (0.1.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
     newrelic_rpm (3.9.5.251)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (~> 1.2)
     omniauth (1.2.1)
       hashie (>= 1.2, < 3)
       rack (~> 1.0)
+    omniauth-google-oauth2 (0.2.6)
+      omniauth (> 1.0)
+      omniauth-oauth2 (~> 1.1)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     parallel (1.0.0)
     pg (0.17.1)
     phantomjs (1.9.7.1)
@@ -335,6 +354,7 @@ DEPENDENCIES
   metric_fu
   newrelic_rpm
   omniauth
+  omniauth-google-oauth2
   pg
   poltergeist
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,6 +220,7 @@ GEM
       rack (>= 0.4)
     rack-ssl (1.3.4)
       rack
+    rack-ssl-enforcer (0.2.8)
     rack-test (0.6.2)
       rack (>= 1.0)
     railroady (1.1.1)
@@ -358,6 +359,7 @@ DEPENDENCIES
   pg
   poltergeist
   puma
+  rack-ssl-enforcer
   railroady
   rails (= 3.2.18)
   rails_12factor

--- a/README_FOR_APP.md
+++ b/README_FOR_APP.md
@@ -29,11 +29,13 @@ matches their Google email address.
 Currently this must be done manually.
 
 **In production**, you must setup a [Google OAuth2 API
-key](https://console.developers.google.com/project/628865701741/apiui/credential?clientType&authuser=0)
-and set environment variable `GOOGLE_CLIENT_ID` to the OAuth2 client ID
+key and enable Google+ and Google Contacts on your Heroku
+deployment](https://github.com/zquestz/omniauth-google-oauth2), and wait
+a few minutes for the changes to take effect on Google's side.
+You must also set environment variable `GOOGLE_CLIENT_ID` to the OAuth2 client ID
 provided by Google and `GOOGLE_CLIENT_SECRET` to the client secret
-provided by Google for that key.  (On Heroku, you can set an app's
-environment variables on its Settings page.)  **In addition,** on the
+provided by Google for that key.  (On Heroku, you do this
+on the app's Settings page.)  **In addition,** on the
 Google settings for that API key, the
 "Redirect URI" must be
 `https://your-app-name.herokuapp.com/auth/google_oauth2/callback`.

--- a/README_FOR_APP.md
+++ b/README_FOR_APP.md
@@ -16,6 +16,44 @@ are initials of developer, eg "AF") for new features,
 0. We are using [CodeClimate to monitor our code
 quality](https://codeclimate.com/github/ucberkeley/moocchat)
 
+## Developers -- important note on authentication
+
+Google OAuth2 is used to enforce that only Instructors and
+Administrators may administer content.  To make someone an instructor or
+administrator:
+
+0. Make sure the `type` field (i.e. subclass) of their entry
+in the `users` table is set to either `Instructor` or `Administrator`
+0. Make sure they have a nonblank `email` attribute that exactly
+matches their Google email address.  
+Currently this must be done manually.
+
+**In production**, you must setup a [Google OAuth2 API
+key](https://console.developers.google.com/project/628865701741/apiui/credential?clientType&authuser=0)
+and set environment variable `GOOGLE_CLIENT_ID` to the OAuth2 client ID
+provided by Google and `GOOGLE_CLIENT_SECRET` to the client secret
+provided by Google for that key.  (On Heroku, you can set an app's
+environment variables on its Settings page.)  **In addition,** on the
+Google settings for that API key, the
+"Redirect URI" must be
+`https://your-app-name.herokuapp.com/auth/google_oauth2/callback`.
+
+**In development**, Google OAuth2 is turned off, and the "Google Login"
+button is replaced by a "Dev Mode Login" button.  On the login form,
+enter your name and email exactly as they'd appear if you were
+authenticating with Google, and you'll be logged in.
+
+**For testing (Cucumber scenarios)**, if your scenario **specifically**
+deals with testing authentication directly, give it the tag
+`@auth_test`.  You will then have to create OmniAuth mocks to simulate
+the desired result of an authentication transaction; see
+`features/step_definitions/auth_steps.rb` for an example.  All
+scenarios WITHOUT this tag will be preceded by a `Before` action (see
+`features/support/env.rb`) that simulates an admin login, so these
+scenarios can assume that an admin is logged in.
+
+**For testing (RSpec controller tests)**:  TBD
+
 ## Developers -- detailed setting up on a fresh Ubuntu 14.04.1 install
 
 0. `sudo apt-get update && sudo apt-get upgrade`

--- a/app/assets/stylesheets/bootstrap.css
+++ b/app/assets/stylesheets/bootstrap.css
@@ -547,7 +547,8 @@ h4 small,
 
 .page-header {
   padding-bottom: 9px;
-  margin: 40px 0 20px;
+  padding-right: 10px;
+  margin: 20px;
   border-bottom: 1px solid #eeeeee;
 }
 
@@ -2355,6 +2356,11 @@ input[type="submit"].btn-block,
 input[type="reset"].btn-block,
 input[type="button"].btn-block {
   width: 100%;
+}
+
+.button_to,
+.button_to div {
+  display: inline;
 }
 
 .fade {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,17 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   helper :all
+
+  before_filter :require_authenticated_user
+
+  protected
+
+  def require_authenticated_user
+    @user = User.find_by_id(session[:user_id]) # == nil if user_id is nil
+    unless @user.try(:authorized?)
+      flash[:notice] ||= 'You must be an Instructor or Administrator to do this action.'
+      redirect_to root_path
+    end
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,4 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
   helper :all
-  def getSession
-  	session 
-  end
 end

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -1,6 +1,0 @@
-class ChatController < ApplicationController
-	def chatpage
-		@chat_session = getSession
-	end
-
-end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,44 @@
+class SessionsController < ApplicationController
+  skip_before_filter :require_authenticated_user
+  ssl_required :try_login if Rails.env.production?
+  
+  def try_login
+    email = get_auth_provider_email
+    unless email
+      logger.warn "No email address in auth return"
+      redirect_to(:back, :notice => "Login failed: Google didn't provide your email address.")
+      return
+    end
+    if (u = User.find_by_email(email)) && u.authorized?
+      session[:user_id] = u.id
+      logger.warn "Authenticated #{email}"
+      redirect_to conditions_path
+    else
+      session.delete(:user_id)
+      logger.warn "#{email} is not an Instructor or Admin"
+      redirect_to root_path, :notice => "Sorry, #{email} isn't an instructor or administrator."
+    end
+  end
+
+  def login_failed
+    redirect_to root_path, :notice => "Incorrect Google credentials."
+  end
+
+  def destroy
+    session.delete(:user_id)
+    @user = nil
+    redirect_to root_path
+  end
+
+  protected
+
+  def get_auth_provider_email
+    if (hash = request.env['omniauth.auth']) &&
+        (hash[:info].kind_of?(Hash))
+      hash[:info][:email]
+    else
+      nil
+    end
+  end
+
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,5 @@
 class SessionsController < ApplicationController
   skip_before_filter :require_authenticated_user
-  ssl_required :try_login if Rails.env.production?
   
   def try_login
     email = get_auth_provider_email

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
 
   before_filter :check_if_test_user, :except => [:create, :static]
+  skip_before_filter :require_authenticated_user
 
   protected
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  skip_before_filter :require_authenticated_user
   def record_consent
     # Do not require request.xhr? because it blocks JSONP
     users = User.where(['name = ?', params[:username]])

--- a/app/controllers/waiting_rooms_controller.rb
+++ b/app/controllers/waiting_rooms_controller.rb
@@ -1,5 +1,7 @@
 class WaitingRoomsController < ApplicationController
 
+  skip_before_filter :require_authenticated_user, :only => %w(group_formation_times)
+
   def group_formation_times
     waiting_room = WaitingRoom.where(
       ['condition_id = ? AND activity_schema_id = ?',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,11 @@
 class User < ActiveRecord::Base
-  attr_accessible :name
+  attr_accessible :name, :email
+  validates_uniqueness_of :email, :allow_nil => true
+  validates :email, :format => {:with => /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i }, :allow_nil => true
+  def authorized?
+    self.class == Administrator || self.class == Instructor
+  end
+  def self.authorized?(id)
+    User.find_by_id(id).try(:authorized?)
+  end
 end

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -1,0 +1,12 @@
+.text-right
+  - if @user
+    - %w(conditions questions activity_schemas templates).each do |model|
+      = link_to model.humanize, self.send("#{model}_path"), :class => 'btn btn-primary'
+    = button_to 'Log Out', logout_path, :class => 'btn btn-danger'
+    = @user.email
+  - else
+    - if Rails.env.production?
+      = link_to 'Google Login', '/auth/google_oauth2', :class => 'btn'
+    - else
+      = link_to 'Dev Mode login', '/auth/developer', :class => 'btn'
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,5 +9,6 @@
     = javascript_include_tag "application"
     = csrf_meta_tags
   %body.admin
+    .page-header= render :partial => 'layouts/header'
     .notice= flash[:notice]
     .container= yield

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -6,5 +6,6 @@ std_opts = "-r features --format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict 
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
-autotest: -r features --format pretty --color
+#autotest: -r features --format pretty --color
+autotest: --tags @wip:3 --wip features
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,11 @@
 Moocchat::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
+  # Set a Google client id and secret for authenticaiton with Google in development
+  # These will only redirect back to https://localhost:3000/auth/google-oauth2/callback
+  ENV['GOOGLE_CLIENT_ID'] = '628865701741-j9rip8s981rouni6piq2c3o49rb28h13.apps.googleusercontent.com'
+  ENV['GOOGLE_CLIENT_SECRET'] = 'e2b_98_cXVGcuib08qzW_Oxo'
+
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Moocchat::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Moocchat::Application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # ...except for simple requests to get info about waiting rooms' next group-formation time, etc
-  config.middleware.use Rack::SslEnforcer, :ignore => %r{^/group_formation_times/}
+  config.middleware.use Rack::SslEnforcer, :ignore => [%r{^/group_formation_times/}, %r{^/users/}]
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,8 @@ Moocchat::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # ...except for simple requests to get info about waiting rooms' next group-formation time, etc
+  config.middleware.use Rack::SslEnforcer, :ignore => %r{^/waiting_rooms/}
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Moocchat::Application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # ...except for simple requests to get info about waiting rooms' next group-formation time, etc
-  config.middleware.use Rack::SslEnforcer, :ignore => %r{^/waiting_rooms/}
+  config.middleware.use Rack::SslEnforcer, :ignore => %r{^/group_formation_times/}
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,6 +1,10 @@
 Moocchat::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb
 
+  # Turn on test mode for OmniAuth - lets you mock return value of auth hash in
+  # OmniAuth.config.mock_auth[:provider_name]
+  OmniAuth.config.test_mode = true
+
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,5 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  provider :developer unless Rails.env.production?
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,10 +8,6 @@ Moocchat::Application.routes.draw do
   resources :questions
   resources :templates
 
-  #a simple get to redirect to this page
-  get 'chat' => 'chat#chatpage'
-  get 'test' => 'chat#chattest'
-
   root :to => 'tasks#static', :as => 'static'
 
   # get next group-formation time for a given condition + activity_schema

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,16 @@ Moocchat::Application.routes.draw do
   resources :questions
   resources :templates
 
-  root :to => 'tasks#static', :as => 'static'
+  root :to => 'tasks#static', :as => 'root'
 
   # get next group-formation time for a given condition + activity_schema
   get '/group_formation_times/:activity_schema_id/:condition_id' =>
     'waiting_rooms#group_formation_times'
+
+  # login as an authenticated user
+  match '/auth/:provider/callback', :to => 'sessions#try_login'
+  get '/auth/failure', :to => 'sessions#login_failed'
+  post '/logout', :to => 'sessions#destroy'
 
   # login and establish a session
   post '/tasks/:learner_name/:activity_schema_id/:condition_id' => 'tasks#create', :as => 'task_create'

--- a/db/migrate/20141111193352_add_email_to_user.rb
+++ b/db/migrate/20141111193352_add_email_to_user.rb
@@ -10,7 +10,9 @@ class AddEmailToUser < ActiveRecord::Migration
       'Bjoern Hartmann (Berkeley)' => 'bjoern@berkeley.edu',
       'D Coetzee (Berkeley)' => 'dcoetzee@berkeley.edu',
       'D Coetzee' => 'dcoetzee@gmail.com',
+      'Yeung John Li (Berkeley)' => 'liyeungjohn@berkeley.edu',
       'Marti Hearst (Berkeley)' => 'hearst@berkeley.edu',
+      'Claire Thompson (Berkeley)' => 'cthompson44@berkeley.edu',
       'Claire Thompson' => 'clairethomp44@gmail.com'
     }
     admins.each_pair do |name,email|

--- a/db/migrate/20141111193352_add_email_to_user.rb
+++ b/db/migrate/20141111193352_add_email_to_user.rb
@@ -1,0 +1,23 @@
+class AddEmailToUser < ActiveRecord::Migration
+  def up
+    add_column :users, :email, :string, :null => true, :default => nil
+    add_index :users, :email
+    Administrator.delete_all
+    admins = {
+      'Armando Fox' => 'armandofox@gmail.com',
+      'Armando Fox (Berkeley)' => 'fox@berkeley.edu',
+      'Bjoern Hartmann' => 'bjoern.hartmann@gmail.com',
+      'Bjoern Hartmann (Berkeley)' => 'bjoern@berkeley.edu',
+      'D Coetzee (Berkeley)' => 'dcoetzee@berkeley.edu',
+      'D Coetzee' => 'dcoetzee@gmail.com',
+      'Marti Hearst (Berkeley)' => 'hearst@berkeley.edu',
+      'Claire Thompson' => 'clairethomp44@gmail.com'
+    }
+    admins.each_pair do |name,email|
+      Administrator.create! :name => name, :email => email
+    end
+  end
+  def down
+    remove_column :users, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20141106184134) do
+ActiveRecord::Schema.define(:version => 20141111193352) do
 
   create_table "activity_schemas", :force => true do |t|
     t.datetime "created_at",    :null => false
@@ -119,11 +119,13 @@ ActiveRecord::Schema.define(:version => 20141106184134) do
     t.datetime "updated_at",                           :null => false
     t.string   "type"
     t.string   "name"
-    t.boolean  "for_testing",       :default => false
     t.boolean  "consent"
     t.datetime "consent_timestamp"
+    t.boolean  "for_testing", :default => false
+    t.string   "email"
   end
 
+  add_index "users", ["email"], :name => "index_users_on_email"
   add_index "users", ["name"], :name => "index_users_on_name", :unique => true
 
   create_table "waiting_rooms", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(:version => 20141111193352) do
     t.string   "name"
     t.boolean  "consent"
     t.datetime "consent_timestamp"
-    t.boolean  "for_testing", :default => false
+    t.boolean  "for_testing",       :default => false
     t.string   "email"
   end
 

--- a/features/authentication.feature
+++ b/features/authentication.feature
@@ -1,0 +1,29 @@
+@auth_test
+Feature: authentication
+
+  So that I can limit access to sensitive functions
+  As the app administrator
+  I want to limit actions to Instructors and Admins with registered Google IDs
+
+Scenario: non-logged-in user cannot see sensitive pages
+
+  When I go to the questions page
+  Then I should see "You must be an Instructor or Administrator to do this action."
+  And I should be on the home page
+
+Scenario: successful login via Google
+
+  Given an Instructor "Armando Fox" with Google email "armandofox@gmail.com"
+  When I login successfully via Google as "Armando Fox <armandofox@gmail.com>"
+  And I go to the questions page
+  Then I should see "armandofox@gmail.com"
+  And I should be on the questions page
+
+Scenario: Google login, but user not authorized locally
+
+  Given a Learner "Armando Fox" with Google email "armandofox@gmail.com"
+  When I login successfully via Google as "Armando Fox <armandofox@gmail.com>"
+  Then I should see "Sorry, armandofox@gmail.com isn't an instructor or administrator."
+  And I should be on the home page
+
+Scenario: failed login via Google  

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -1,0 +1,14 @@
+When /^I login successfully via Google as "(.*) (.*) <(.*)>"$/ do |first,last,email|
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:google_oauth2] = OmniAuth::AuthHash.new({
+      :provider => 'google_oauth2',
+      :uid => '12345',
+      :info => {
+        :name => "#{first} #{last}",
+        :email => email,
+        :first_name => first,
+        :last_name => last
+      }
+    })
+  visit '/auth/google_oauth2'
+end

--- a/features/step_definitions/learner_steps.rb
+++ b/features/step_definitions/learner_steps.rb
@@ -1,3 +1,0 @@
-Given /^a new learner named "(.*?)"$/ do |name|
-  @learner = create(:learner, :name => name)
-end

--- a/features/step_definitions/task_steps.rb
+++ b/features/step_definitions/task_steps.rb
@@ -1,5 +1,5 @@
 Given(/^I start on the Static Page$/) do 
-	visit static_path
+	visit root_path
 end
 
 When /^I post to the URL for learner:\s*"(.+)",\s*activity schema:\s*"(.+)",\s*condition:\s*"(.+)"$/ do |learner, activity_schema, condition|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -1,0 +1,7 @@
+Given /^a new learner named "(.*?)"$/ do |name|
+  @learner = create(:learner, :name => name)
+end
+Given /^an? (Learner|Instructor|Administrator) "(.*)" with Google email "(.*)"$/ do |role,name,email|
+  role = role.downcase
+  self.instance_variable_set("@#{role}", create(role, :name => name, :email => email))
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -38,6 +38,32 @@ Capybara.javascript_driver = :poltergeist
 #
 ActionController::Base.allow_rescue = false
 
+# For any scenarios that DO NOT explicitly test authentication, assume logged-in user is an Admin.
+Before '~@auth_test' do
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new( {
+    :provider => 'google_oauth2',
+      :uid => '12345',
+      :info => {
+        :name => "Anna Admin",
+        :email => 'anna_admin@gmail.com',
+        :first_name => 'Anna',
+        :last_name => 'Admin'
+      }
+    })
+  create :administrator, :name => 'Anna Admin', :email => 'anna_admin@gmail.com'
+  visit '/auth/google_oauth2'
+end
+After '~@auth_test' do
+  Administrator.find_by_email('anna_admin@gmail.com').destroy
+  OmniAuth.config.mock_auth.delete(:default)
+end
+
+# For scenarios that DO test authentication, tear down their setup after running.
+After '@auth_test' do
+  OmniAuth.config.mock_auth = {}
+end
+
 # Remove/comment out the lines below if your app doesn't have a database.
 # For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
 begin

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,10 +56,12 @@ FactoryGirl.define do
     time_filler {create :activity_schema, :questions => [create(:question)]}
   end
 
-  factory :learner do
-    sequence(:name) { |n| "Learner#{n}" }
+  %w(learner instructor administrator).each do |user_type|
+    factory user_type do
+      sequence(:name) { |n| "#{user_type}#{n}" }
+    end
   end
-
+  
   factory :question do
     sequence(:text) { |n| "Question #{n}" }
     answers ["Wrong", "Wrong", "Right"]

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe User do
+  describe 'authentication' do
+    before :each do
+      @instructor = create :instructor
+      @administrator = create :administrator
+      @learner = create :learner
+    end
+    specify 'for administrators and instructors' do
+      expect(@instructor).to be_authorized
+      expect(@administrator).to be_authorized
+    end
+    specify 'for learners' do
+      expect(@learner).not_to be_authorized
+    end
+    specify 'for legit id' do
+      expect(User.authorized?(@instructor.id)).to be_true
+      expect(User.authorized?(@administrator.id)).to be_true
+      expect(User.authorized?(@learner.id)).to be_false
+    end
+    specify 'for bogus id' do
+      expect(User.authorized?(999999)).to be_false
+    end
+    specify 'for nil id' do
+      expect(User.authorized?(nil)).to be_false
+    end
+  end
+end
+
+  


### PR DESCRIPTION
I haven't squashed the commits, but this branch uses OmniAuth to require login via Google for instructors/admins to modify content.  See README_FOR_APP.md for details.
I haven't merged to master yet but I have rebased and all tests are passing.  Since I am not the experiment owner, someone other than me should decide when to merge to master and deploy.
Notable things that affect development:
- SSL is now turned on for the app (since credentials are being passed around), _but_ it is not forced for the API calls about user consent or getting waiting room group-formation times.
- A Google OAuth client key and client secret must be part of the environment variables in order for auth to work. I set this up already for moocchat.herokuapp.com, but if you want the app to also work in your "personal" production environment on heroku, you'll have to setup your own client key & secret; again, see `README_FOR_APP.md`
- In development, SSL is turned off, and authentication is not via Google but simply by typing your email address (for most of you, either your berkeley or gmail address should work; see the most recent migration for a list of all the google IDs).  Regardless which authentication mode is used, in order to be an Admin or Instructor you have to have the right kind of Users table record and it must contain an email address matching your Gmail or Bmail one.  (The latest migration adds all these to the production database and your development database.)

This is ready to be merged and deployed but I didn't want to step on anyone else's testing or dev.  NOTE that when it's deployed you have to `heroku run rake db:migrate` to get the latest migration in place.

(Alternatively, if this seems too much of a risk and the experiment ends up starting tomorrow as we hope it will, we could delay this merge if we trust the MOOC students not to try to screw things up.)
